### PR TITLE
ENH: Add merge subcommand, refactor render subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +751,7 @@ dependencies = [
 name = "rastertiler"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "crossbeam",
  "gdal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+anyhow = "1.0"
 clap = { version = "4.4", features = ["derive"] }
 crossbeam = "0.8"
 gdal = "0.16"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ From a local clone of this repository
 Build and run this in development mode:
 
 ```bash
-cargo run -- <tif filename> <mbtiles filename>
+cargo run -- render <tif filename> <mbtiles filename>
 ```
 
 Or build a release version:
@@ -29,34 +29,44 @@ cargo build --release
 ## Usage
 
 ```bash
-USAGE:
-    rastertiler [OPTIONS] <TIFF> <MBTILES>
+Usage: rastertiler <COMMAND>
 
-ARGS:
-    <TIFF>       Input GeoTIFF filename
-    <MBTILES>    Output MBTiles filename
+Commands:
+  merge   merge two MBTiles files into a single MBTiles file
+  render  render a single-band GeoTIFF to a MBTiles file
+  help    Print this message or the help of the given subcommand(s)
 
-OPTIONS:
-    -a, --attribution <ATTRIBUTION>    Minimum zoom level
-    -c, --colormap <COLORMAP>          Colormap as comma-delmited value:hex color pairs, e.g.,
-                                       "<value>:<hex>,<value:hex>" can only be provided for uint8
-                                       data
-    -d, --description <DESCRIPTION>    Tileset description
-        --disable-overviews            Disable use of overviews in source GeoTIFF. This will yield
-                                       more precise results at the expense of slower performance
-    -h, --help                         Print help information
-    -n, --name <NAME>                  Tileset name
-    -s, --tilesize <TILESIZE>          Tile size in pixels per side [default: 512]
-    -V, --version                      Print version information
-    -w, --workers <WORKERS>            Number of workers to create tiles [default: 4]
-    -z, --maxzoom <MAXZOOM>            Maximum zoom level [default: 0]
-    -Z, --minzoom <MINZOOM>            Minimum zoom level [default: 0]
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+```
+
+### Render tiles
+
+```bash
+Usage: rastertiler render [OPTIONS] <TIFF> <MBTILES>
+
+Arguments:
+  <TIFF>     Input GeoTIFF filename
+  <MBTILES>  Output MBTiles filename
+
+Options:
+  -Z, --minzoom <MINZOOM>          Minimum zoom level [default: 0]
+  -z, --maxzoom <MAXZOOM>          Maximum zoom level [default: 0]
+  -s, --tilesize <TILESIZE>        Tile size in pixels per side [default: 512]
+  -n, --name <NAME>                Tileset name
+  -d, --description <DESCRIPTION>  Tileset description
+  -a, --attribution <ATTRIBUTION>  Minimum zoom level
+  -w, --workers <WORKERS>          Number of workers to create tiles [default: 4]
+  -c, --colormap <COLORMAP>        Colormap as comma-delmited value:hex color pairs, e.g., "<value>:<hex>,<value:hex>" can only be provided for uint8 data
+      --disable-overviews          Disable use of overviews in source GeoTIFF. This will yield more precise results at the expense of slower performance
+  -h, --help                       Print help
 ```
 
 To create MBtiles from a single-band `uint8` GeoTIFF:
 
 ```bash
-rastertiler example.tif example.mbtiles --minzoom 0 --maxzoom 2
+rastertiler render example.tif example.mbtiles --minzoom 0 --maxzoom 2
 ```
 
 By default, this will render grayscale PNG tiles.
@@ -64,7 +74,7 @@ By default, this will render grayscale PNG tiles.
 To use a colormap to render the `uint8` data to paletted PNG
 
 ```bash
-rastertiler create example.tif example.mbtiles --minzoom 0 --maxzoom 2 --colormap "1:#686868,2:#fbb4b9,3:#c51b8a,4:#49006a"
+rastertiler render example.tif example.mbtiles --minzoom 0 --maxzoom 2 --colormap "1:#686868,2:#fbb4b9,3:#c51b8a,4:#49006a"
 ```
 
 Any values in the GeoTIFF that are not present in the colormap are converted to
@@ -77,6 +87,24 @@ hold all values of the colormap plus a transparency value:
 -   a colormap with 3 values will be output as a 2-bit PNG
 -   a colormap with 14 values will be output as a 4-bit PNG
 -   otherwise will be output as an 8-bit PNG
+
+### Merge tilesets
+
+You may need to render a given dataset at different zoom levels, such as using
+internal overviews for low zooms and no overviews for higher zooms. You can use
+the `merge` subcommand to merge these into a single tileset.
+
+```bash
+Usage: rastertiler merge <left MBTiles file> <right MBTiles file> <output MBTiles file>
+
+Arguments:
+  <left MBTiles file>
+  <right MBTiles file>
+  <output MBTiles file>
+
+Options:
+  -h, --help  Print help
+```
 
 ## Credits
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,11 +117,6 @@ fn main() {
         .exit();
     }
 
-    // let allowed_dtype: bool = match dtype {
-    //     GdalDataType::UInt8 => true,
-    //     GdalDataType::UInt32 => true,
-    //     _ => false,
-    // };
     let allowed_dtype: bool = matches!(dtype, GdalDataType::UInt8 | GdalDataType::UInt32);
 
     if !allowed_dtype {
@@ -231,7 +226,7 @@ fn main() {
         })
         .unwrap();
 
-        db.close().unwrap();
+        db.update_index().unwrap();
     }
 
     // change the database back to non-WAL mode

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,11 +90,7 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     match &cli.command {
         Commands::Merge { left, right, out } => {
-            println!("merge: {:?} + {:?} => {:?}", left, right, out);
-
             merge(left, right, out)?;
-
-            return Ok(());
         }
         Commands::Render {
             tiff,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,8 @@
-use std::error::Error;
-// use std::fs;
 use std::path::PathBuf;
 
+use anyhow::Result;
 use clap::error::ErrorKind;
-use clap::{CommandFactory, Parser};
-use crossbeam::channel;
-// use gdal::spatial_ref::SpatialRef;
-use gdal::raster::GdalDataType;
-use indicatif::{ProgressBar, ProgressStyle};
+use clap::{CommandFactory, Parser, Subcommand};
 
 mod affine;
 mod array;
@@ -15,222 +10,131 @@ mod bounds;
 mod dataset;
 mod mbtiles;
 mod png;
+mod render;
 mod tileid;
 mod window;
 
-// use crate::affine::Affine;
-// use crate::dataset::{write_raster, Dataset};
-use crate::dataset::Dataset;
-use crate::mbtiles::MBTiles;
-use crate::png::{ColormapEncoder, Encode, GrayscaleEncoder, RGBEncoder, Rgb8};
-use crate::tileid::{TileID, TileRange};
+use crate::mbtiles::merge;
+use crate::render::render_tiles;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 struct Cli {
-    #[arg(value_parser=file_exists)]
-    /// Input GeoTIFF filename
-    tiff: PathBuf,
-
-    /// Output MBTiles filename
-    mbtiles: PathBuf,
-
-    /// Minimum zoom level
-    #[clap(short = 'Z', long, default_value_t = 0, value_parser=parse_zoom)]
-    minzoom: u8,
-
-    /// Maximum zoom level
-    #[clap(short = 'z', long, default_value_t = 0, value_parser=parse_zoom)]
-    maxzoom: u8,
-
-    /// Tile size in pixels per side
-    #[clap(short = 's', long, default_value_t = 512)]
-    tilesize: u16,
-
-    /// Tileset name
-    #[clap(short = 'n', long)]
-    name: Option<String>,
-
-    /// Tileset description
-    #[clap(short = 'd', long)]
-    description: Option<String>,
-
-    /// Minimum zoom level
-    #[clap(short = 'a', long)]
-    attribution: Option<String>,
-
-    /// Number of workers to create tiles
-    #[clap(short = 'w', long, default_value_t = 4)]
-    workers: u8,
-
-    /// Colormap as comma-delmited value:hex color pairs, e.g., "<value>:<hex>,<value:hex>"
-    /// can only be provided for uint8 data
-    #[clap(short = 'c', long)]
-    colormap: Option<String>,
-
-    /// Disable use of overviews in source GeoTIFF. This will yield more precise
-    /// results at the expense of slower performance
-    #[clap(long, action)]
-    disable_overviews: bool,
+    #[clap(subcommand)]
+    command: Commands,
 }
 
-fn main() {
-    let args = Cli::parse();
+#[derive(Subcommand, Debug)]
+enum Commands {
+    #[command(about = "merge two MBTiles files into a single MBTiles file")]
+    Merge {
+        #[arg(name="left MBTiles file", value_parser=file_exists)]
+        left: PathBuf,
 
-    println!(
-        "Call: {:?} ({}) {:?}, name:{:?}, zooms: {}-{}",
-        args.tiff,
-        args.tiff.exists(),
-        args.mbtiles,
-        args.name,
-        args.minzoom,
-        args.maxzoom
-    );
+        #[arg(name="right MBTiles file", value_parser=file_exists)]
+        right: PathBuf,
 
-    if args.minzoom > args.maxzoom {
-        let mut cmd = Cli::command();
-        cmd.error(
-            ErrorKind::ArgumentConflict,
-            "minzoom must be less than maxzoom",
-        )
-        .exit();
-    }
+        #[arg(name = "output MBTiles file")]
+        out: PathBuf,
+    },
+    #[command(about = "render a single-band GeoTIFF to a MBTiles file")]
+    Render {
+        #[arg(value_parser=file_exists)]
+        /// Input GeoTIFF filename
+        tiff: PathBuf,
 
-    // default tileset name to output filename
-    let name = args.name.unwrap_or(String::from(
-        args.mbtiles.file_stem().unwrap().to_str().unwrap(),
-    ));
+        /// Output MBTiles filename
+        mbtiles: PathBuf,
 
-    let dataset = Dataset::open(&args.tiff, false).unwrap();
-    let band = dataset.band(1).unwrap();
-    let dtype = band.band_type();
-    let geo_bounds = dataset.geo_bounds().unwrap();
-    let mercator_bounds = dataset.mercator_bounds().unwrap();
+        /// Minimum zoom level
+        #[clap(short = 'Z', long, default_value_t = 0, value_parser=parse_zoom)]
+        minzoom: u8,
 
-    // colormap is only allowed for u8 data
-    if args.colormap.is_some() && dtype != GdalDataType::UInt8 {
-        let mut cmd = Cli::command();
-        cmd.error(
-            ErrorKind::ArgumentConflict,
-            "colormap can only be provided for uint8 data",
-        )
-        .exit();
-    }
+        /// Maximum zoom level
+        #[clap(short = 'z', long, default_value_t = 0, value_parser=parse_zoom)]
+        maxzoom: u8,
 
-    let allowed_dtype: bool = matches!(dtype, GdalDataType::UInt8 | GdalDataType::UInt32);
+        /// Tile size in pixels per side
+        #[clap(short = 's', long, default_value_t = 512)]
+        tilesize: u16,
 
-    if !allowed_dtype {
-        let mut cmd = Cli::command();
-        cmd.error(ErrorKind::ArgumentConflict, "data type is not supported")
-            .exit();
-    }
+        /// Tileset name
+        #[clap(short = 'n', long)]
+        name: Option<String>,
 
-    let mut metadata = Vec::<(&str, &str)>::new();
-    metadata.push(("name", &name));
+        /// Tileset description
+        #[clap(short = 'd', long)]
+        description: Option<String>,
 
-    if args.description.is_some() {
-        metadata.push(("description", args.description.as_ref().unwrap()));
-    }
+        /// Minimum zoom level
+        #[clap(short = 'a', long)]
+        attribution: Option<String>,
 
-    if args.attribution.is_some() {
-        metadata.push(("attribution", args.attribution.as_ref().unwrap()));
-    }
+        /// Number of workers to create tiles
+        #[clap(short = 'w', long, default_value_t = 4)]
+        workers: u8,
 
-    let minzoom_str = format!("{}", args.minzoom);
-    let maxzoom_str = format!("{}", args.maxzoom);
+        /// Colormap as comma-delmited value:hex color pairs, e.g., "<value>:<hex>,<value:hex>"
+        /// can only be provided for uint8 data
+        #[clap(short = 'c', long)]
+        colormap: Option<String>,
 
-    metadata.push(("minzoom", &minzoom_str));
-    metadata.push(("maxzoom", &maxzoom_str));
+        /// Disable use of overviews in source GeoTIFF. This will yield more precise
+        /// results at the expense of slower performance
+        #[clap(long, action)]
+        disable_overviews: bool,
+    },
+}
 
-    let bounds_str = format!(
-        "{:.5},{:.5},{:.5},{:.5}",
-        geo_bounds.xmin, geo_bounds.ymin, geo_bounds.xmax, geo_bounds.ymax
-    );
-    metadata.push(("bounds", &bounds_str));
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match &cli.command {
+        Commands::Merge { left, right, out } => {
+            println!("merge: {:?} + {:?} => {:?}", left, right, out);
 
-    let center_str = format!(
-        "{:.5},{:.5},{}",
-        (geo_bounds.xmax - geo_bounds.xmin) / 2.,
-        (geo_bounds.ymax - geo_bounds.ymin) / 2.,
-        args.minzoom
-    );
-    metadata.push(("center", &center_str));
+            merge(left, right, out)?;
 
-    metadata.push(("type", "overlay"));
-    metadata.push(("format", "png"));
-    metadata.push(("version", "1.0.0"));
-
-    // close dataset; will be opened in each thread
-    drop(dataset);
-
-    // in a block so that connections are dropped to force flush / close
-    {
-        let db = MBTiles::new(&args.mbtiles, args.workers).unwrap();
-        db.set_metadata(&metadata).unwrap();
-
-        let (snd, rcv) = channel::bounded(1);
-
-        crossbeam::scope(|s| {
-            // add tiles to queue
-            s.spawn(|_| {
-                let mut tiles: TileRange;
-                for zoom in args.minzoom..(args.maxzoom + 1) {
-                    tiles = TileRange::new(zoom, &mercator_bounds);
-                    let bar = ProgressBar::new(tiles.count() as u64)
-                        .with_style(ProgressStyle::default_bar().template(
-                            "{prefix:<8} {bar:50} {pos}/{len} {msg} [elapsed: {elapsed_precise}]]",
-                        ).unwrap())
-                        .with_prefix(format!("zoom: {}", zoom));
-
-                    for tile_id in tiles.iter() {
-                        snd.send(tile_id).unwrap();
-                        bar.inc(1);
-                    }
-
-                    bar.finish();
-                }
-
-                drop(snd);
-            });
-
-            let tiff = &args.tiff;
-            let db = &db;
-            let colormap = &args.colormap;
-            for _ in 0..args.workers {
-                let rcv = rcv.clone();
-
-                s.spawn(move |_| {
-                    match dtype {
-                        GdalDataType::UInt8 => {
-                            worker_u8(
-                                rcv,
-                                tiff,
-                                db,
-                                args.tilesize,
-                                colormap,
-                                args.disable_overviews,
-                            )
-                            .unwrap();
-                        }
-                        GdalDataType::UInt32 => {
-                            worker_u32(rcv, tiff, db, args.tilesize, args.disable_overviews)
-                                .unwrap();
-                        }
-                        // supported data types validated above
-                        _ => {
-                            unreachable!("data type not supported");
-                        }
-                    }
-                });
+            return Ok(());
+        }
+        Commands::Render {
+            tiff,
+            mbtiles,
+            minzoom,
+            maxzoom,
+            tilesize,
+            name,
+            description,
+            attribution,
+            workers,
+            colormap,
+            disable_overviews,
+        } => {
+            if minzoom > maxzoom {
+                let mut cmd = Cli::command();
+                cmd.error(
+                    ErrorKind::ArgumentConflict,
+                    "minzoom must be less than maxzoom",
+                )
+                .exit();
             }
-        })
-        .unwrap();
 
-        db.update_index().unwrap();
+            render_tiles(
+                tiff,
+                mbtiles,
+                *minzoom,
+                *maxzoom,
+                *tilesize,
+                name,
+                description,
+                attribution,
+                *workers,
+                colormap,
+                *disable_overviews,
+            )?;
+        }
     }
 
-    // change the database back to non-WAL mode
-    MBTiles::flush(&args.mbtiles).unwrap();
+    Ok(())
 }
 
 fn file_exists(s: &str) -> Result<PathBuf, String> {
@@ -251,143 +155,6 @@ fn parse_zoom(s: &str) -> Result<u8, String> {
         return Err(String::from("must be no greater than 24"));
     }
     Ok(zoom)
-}
-
-fn worker_u8(
-    tiles: channel::Receiver<TileID>,
-    tiff_filename: &PathBuf,
-    db: &MBTiles,
-    tilesize: u16,
-    colormap_str: &Option<String>,
-    disable_overviews: bool,
-) -> Result<(), Box<dyn Error>> {
-    let dataset = Dataset::open(tiff_filename, disable_overviews)?;
-    let vrt = dataset.mercator_vrt()?;
-    let band = vrt.band(1)?;
-    let nodata = band.no_data_value().unwrap() as u8;
-
-    let conn = db.get_connection()?;
-
-    let width: u32 = tilesize as u32;
-    let height: u32 = width;
-
-    let (has_colormap, encoder): (bool, Box<dyn Encode<u8>>) = match colormap_str {
-        Some(c) => (
-            true,
-            Box::new(ColormapEncoder::<u8>::from_str(width, height, c, nodata).unwrap()),
-        ),
-        _ => (
-            false,
-            Box::new(GrayscaleEncoder::new(width, height, nodata)),
-        ),
-    };
-
-    // create buffers to receive data; these are automatically filled with
-    // the appropriate nodata value before reading from the raster
-    let mut buffer = vec![0u8; tilesize as usize * tilesize as usize];
-
-    let mut png_data: Vec<u8>;
-
-    for tile_id in tiles.iter() {
-        if vrt.read_tile(&band, tile_id, tilesize, &mut buffer, nodata)? {
-            if has_colormap {
-                png_data = encoder.encode(&buffer)?;
-            } else {
-                png_data = encoder.encode_8bit(&buffer)?;
-            }
-            db.write_tile(&conn, &tile_id, &png_data)?;
-        }
-    }
-
-    Ok(())
-}
-
-fn worker_u32(
-    tiles: channel::Receiver<TileID>,
-    tiff_filename: &PathBuf,
-    db: &MBTiles,
-    tilesize: u16,
-    disable_overviews: bool,
-) -> Result<(), Box<dyn Error>> {
-    let dataset = Dataset::open(tiff_filename, disable_overviews)?;
-    let vrt = dataset.mercator_vrt()?;
-    let band = vrt.band(1)?;
-    let nodata = band.no_data_value().unwrap() as u32;
-
-    let conn = db.get_connection()?;
-
-    let width: u32 = tilesize as u32;
-    let height: u32 = width;
-
-    // get a function pointer for the RGBEncoder that defines specific type of data
-    let rgb_encoder = RGBEncoder::new(width, height, nodata);
-    let encode_rgb = <RGBEncoder as Encode<u32>>::encode_8bit;
-
-    let mut colormap_encoder: ColormapEncoder<u32> =
-        ColormapEncoder::new(width, height, nodata, 256)?;
-
-    let buffer_size = tilesize as usize * tilesize as usize;
-    let mut buffer = vec![nodata; buffer_size];
-    let mut rgb_buffer: Vec<u8> = vec![0u8; buffer_size * 3];
-    let mut color: Rgb8;
-    let mut png_data: Vec<u8>;
-    let mut use_palette: bool;
-
-    for tile_id in tiles.iter() {
-        if vrt.read_tile(&band, tile_id, tilesize, &mut buffer, nodata)? {
-            // // DEBUG: write raw data to TIFF for inspection
-            // let tile_bounds = tile_id.mercator_bounds();
-            // let xres = (tile_bounds.xmax - tile_bounds.xmin) as f64 / tilesize as f64;
-            // let yres = (tile_bounds.ymax - tile_bounds.ymin) as f64 / tilesize as f64;
-            // let transform = Affine::new(xres, 0., tile_bounds.xmin, 0., -yres, tile_bounds.ymax);
-
-            // write_raster(
-            //     format!("/tmp/test_{}_{}_{}.tif", tile_id.zoom, tile_id.x, tile_id.y),
-            //     tilesize as usize,
-            //     tilesize as usize,
-            //     &transform,
-            //     &SpatialRef::from_epsg(3857)?,
-            //     buffer.to_vec(),
-            //     nodata as f64,
-            // )
-            // .unwrap();
-
-            colormap_encoder.colormap.clear();
-            use_palette = true;
-
-            // convert value buffer to 8-bit RGB buffer, ignoring alpha
-            // also build up palette of unique values
-            for (i, &value) in buffer.iter().enumerate() {
-                color = Rgb8::from_u32(value);
-                rgb_buffer[i * 3] = color.r;
-                rgb_buffer[i * 3 + 1] = color.g;
-                rgb_buffer[i * 3 + 2] = color.b;
-
-                if colormap_encoder.colormap.len() < 256 {
-                    colormap_encoder.colormap.add_color(value, color);
-                } else {
-                    use_palette = false;
-                }
-            }
-
-            if use_palette {
-                png_data = colormap_encoder.encode(&buffer)?;
-            } else {
-                png_data = encode_rgb(&rgb_encoder, &rgb_buffer)?;
-            }
-
-            db.write_tile(&conn, &tile_id, &png_data)?;
-
-            // DEBUG: write rendered PNG to file
-            // fs::write(
-            //     format!("/tmp/test_{}_{}_{}.png", tile_id.zoom, tile_id.x, tile_id.y),
-            //     png_data,
-            // )
-            // .unwrap();
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/mbtiles.rs
+++ b/src/mbtiles.rs
@@ -1,12 +1,11 @@
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
-use std::result::Result;
 
+use anyhow::Result;
 use r2d2::PooledConnection;
 use r2d2_sqlite::SqliteConnectionManager;
-use rusqlite::params;
-use rusqlite::Connection;
+use rusqlite::{params, Connection};
 use seahash::hash;
 
 use crate::tileid::TileID;
@@ -36,7 +35,6 @@ const INSERT_TILE_DATA_QUERY: &str =
 const INSERT_TILE_QUERY: &str =
     "INSERT INTO map (zoom_level, tile_column, tile_row, tile_id) VALUES(?, ?, ?, ?)";
 
-// PRAGMA journal_mode=DELETE;
 const UPDATE_INDEX_QUERY: &str = r#"
 CREATE UNIQUE INDEX IF NOT EXISTS map_index ON map (zoom_level, tile_column, tile_row);
 
@@ -50,7 +48,7 @@ pub struct MBTiles {
 }
 
 impl MBTiles {
-    pub fn new(path: &PathBuf, pool_size: u8) -> Result<MBTiles, Box<dyn Error>> {
+    pub fn new(path: &PathBuf, pool_size: u8) -> Result<MBTiles> {
         // always overwrite existing database
         if path.exists() {
             fs::remove_file(path)?;
@@ -66,9 +64,17 @@ impl MBTiles {
         Ok(MBTiles { pool })
     }
 
-    pub fn get_connection(
-        &self,
-    ) -> Result<PooledConnection<SqliteConnectionManager>, Box<dyn Error>> {
+    pub fn open(path: &PathBuf, pool_size: u8) -> Result<MBTiles> {
+        let manager = SqliteConnectionManager::file(path); //.with_init(|c| c.execute_batch(INIT_QUERY));
+
+        let pool = r2d2::Pool::builder()
+            .max_size(pool_size as u32)
+            .build(manager)?;
+
+        Ok(MBTiles { pool })
+    }
+
+    pub fn get_connection(&self) -> Result<PooledConnection<SqliteConnectionManager>> {
         Ok(self.pool.get()?)
     }
 
@@ -94,7 +100,7 @@ impl MBTiles {
         conn: &PooledConnection<SqliteConnectionManager>,
         tile_id: &TileID,
         png_data: &[u8],
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<()> {
         let id = hash(png_data) as i64;
 
         let mut query = conn.prepare_cached(INSERT_TILE_DATA_QUERY)?;
@@ -109,14 +115,14 @@ impl MBTiles {
         Ok(())
     }
 
-    pub fn update_index(&self) -> Result<(), Box<dyn Error>> {
+    pub fn update_index(&self) -> Result<()> {
         let conn = self.pool.get().unwrap();
         conn.execute_batch(UPDATE_INDEX_QUERY)?;
 
         Ok(())
     }
 
-    pub fn flush(path: &PathBuf) -> Result<(), Box<dyn Error>> {
+    pub fn flush(path: &PathBuf) -> Result<()> {
         let conn = Connection::open(path)?;
         conn.execute_batch(RESET_WAL_QUERY)?;
 
@@ -136,4 +142,80 @@ impl MBTiles {
 
         Ok(())
     }
+}
+
+pub fn merge(left: &PathBuf, right: &PathBuf, out: &PathBuf) -> Result<()> {
+    // copy left to output
+    fs::copy(left, out)?;
+
+    let out_mbtiles = MBTiles::open(out, 1).unwrap();
+    let mut conn = out_mbtiles.get_connection().unwrap();
+
+    // make sure index exists so that we insert and ignore existing records
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS map_index ON map (zoom_level, tile_column, tile_row);",
+        (),
+    )?;
+
+    conn.execute(
+        format!("attach '{:}' as source;", right.to_str().unwrap()).as_str(),
+        (),
+    )?;
+
+    let tx = conn.transaction()?;
+
+    {
+        // merge tile indexes
+        tx.execute(
+            "INSERT or IGNORE INTO map(zoom_level, tile_column, tile_row, tile_id) SELECT zoom_level, tile_column, tile_row, tile_id from source.map;",
+            (),
+        )?;
+
+        // merge tile data
+        tx.execute(
+            "INSERT or IGNORE INTO images SELECT * from source.images;",
+            (),
+        )?;
+
+        // update metadata for zoom levels
+        tx.execute(r#"
+            with min_value as(
+                with combined as (
+                    select cast (value as INTEGER) as value from source.metadata where name="minzoom"
+                    UNION
+                    select cast (value as INTEGER) as value from metadata where name="minzoom"
+                )
+                select min(value) as new_value from combined
+            )
+            update metadata
+            set value = cast(min_value.new_value as TEXT)
+            from min_value
+            where name="minzoom";
+
+            with max_value as(
+                with combined as (
+                    select cast (value as INTEGER) as value from source.metadata where name="maxzoom"
+                    UNION
+                    select cast (value as INTEGER) as value from metadata where name="maxzoom"
+                )
+                select max(value) as new_value from combined
+            )
+            update metadata
+            set value = cast(max_value.new_value as TEXT)
+            from max_value
+            where name="maxzoom";
+        "#, ())?;
+    }
+
+    tx.commit()?;
+    conn.execute("detach source;", ())?;
+
+    conn.execute_batch(
+        r#"
+        VACUUM;
+        PRAGMA optimize;
+    "#,
+    )?;
+
+    Ok(())
 }

--- a/src/mbtiles.rs
+++ b/src/mbtiles.rs
@@ -37,7 +37,7 @@ const INSERT_TILE_QUERY: &str =
     "INSERT INTO map (zoom_level, tile_column, tile_row, tile_id) VALUES(?, ?, ?, ?)";
 
 // PRAGMA journal_mode=DELETE;
-const CLOSE_MBTILES_QUERY: &str = r#"
+const UPDATE_INDEX_QUERY: &str = r#"
 CREATE UNIQUE INDEX IF NOT EXISTS map_index ON map (zoom_level, tile_column, tile_row);
 
 PRAGMA wal_checkpoint(TRUNCATE);
@@ -109,9 +109,9 @@ impl MBTiles {
         Ok(())
     }
 
-    pub fn close(&self) -> Result<(), Box<dyn Error>> {
+    pub fn update_index(&self) -> Result<(), Box<dyn Error>> {
         let conn = self.pool.get().unwrap();
-        conn.execute_batch(CLOSE_MBTILES_QUERY)?;
+        conn.execute_batch(UPDATE_INDEX_QUERY)?;
 
         Ok(())
     }

--- a/src/mbtiles.rs
+++ b/src/mbtiles.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use r2d2::PooledConnection;
@@ -144,7 +144,7 @@ impl MBTiles {
     }
 }
 
-pub fn merge(left: &PathBuf, right: &PathBuf, out: &PathBuf) -> Result<()> {
+pub fn merge(left: &PathBuf, right: &Path, out: &PathBuf) -> Result<()> {
     // copy left to output
     fs::copy(left, out)?;
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,301 @@
+use std::error::Error;
+// use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use crossbeam::channel;
+// use gdal::spatial_ref::SpatialRef;
+use gdal::raster::GdalDataType;
+use indicatif::{ProgressBar, ProgressStyle};
+
+// use crate::affine::Affine;
+// use crate::dataset::{write_raster, Dataset};
+use crate::dataset::Dataset;
+use crate::mbtiles::MBTiles;
+use crate::png::{ColormapEncoder, Encode, GrayscaleEncoder, RGBEncoder, Rgb8};
+use crate::tileid::{TileID, TileRange};
+
+pub fn render_tiles(
+    tiff: &PathBuf,
+    mbtiles: &PathBuf,
+    minzoom: u8,
+    maxzoom: u8,
+    tilesize: u16,
+    name: &Option<String>,
+    description: &Option<String>,
+    attribution: &Option<String>,
+    workers: u8,
+    colormap: &Option<String>,
+    disable_overviews: bool,
+) -> Result<()> {
+    println!(
+        "Call: {:?} ({}) {:?}, name:{:?}, zooms: {}-{}",
+        tiff,
+        tiff.exists(),
+        mbtiles,
+        name,
+        minzoom,
+        maxzoom
+    );
+
+    let dataset = Dataset::open(&tiff, false).unwrap();
+    let band = dataset.band(1).unwrap();
+    let dtype = band.band_type();
+    let geo_bounds = dataset.geo_bounds().unwrap();
+    let mercator_bounds = dataset.mercator_bounds().unwrap();
+
+    if colormap.is_some() && dtype != GdalDataType::UInt8 {
+        return Err(anyhow!("colormap can only be provided for uint8 data"));
+    }
+
+    if !matches!(dtype, GdalDataType::UInt8 | GdalDataType::UInt32) {
+        return Err(anyhow!(format!(
+            "data type is not supported: {:}",
+            dtype.name()
+        )));
+    }
+
+    let mut metadata = Vec::<(&str, &str)>::new();
+
+    // default tileset name to output filename
+    let name = match name {
+        Some(n) => n.to_owned(),
+        None => String::from(mbtiles.file_stem().unwrap().to_str().unwrap()),
+    };
+    metadata.push(("name", &name));
+
+    if description.is_some() {
+        metadata.push(("description", description.as_ref().unwrap()));
+    }
+
+    if attribution.is_some() {
+        metadata.push(("attribution", attribution.as_ref().unwrap()));
+    }
+
+    let minzoom_str = format!("{}", minzoom);
+    let maxzoom_str = format!("{}", maxzoom);
+
+    metadata.push(("minzoom", &minzoom_str));
+    metadata.push(("maxzoom", &maxzoom_str));
+
+    let bounds_str = format!(
+        "{:.5},{:.5},{:.5},{:.5}",
+        geo_bounds.xmin, geo_bounds.ymin, geo_bounds.xmax, geo_bounds.ymax
+    );
+    metadata.push(("bounds", &bounds_str));
+
+    let center_str = format!(
+        "{:.5},{:.5},{}",
+        (geo_bounds.xmax + geo_bounds.xmin) / 2.,
+        (geo_bounds.ymax + geo_bounds.ymin) / 2.,
+        minzoom
+    );
+    metadata.push(("center", &center_str));
+
+    metadata.push(("type", "overlay"));
+    metadata.push(("format", "png"));
+    metadata.push(("version", "1.0.0"));
+
+    // close dataset; will be opened in each thread
+    drop(dataset);
+
+    // in a block so that connections are dropped to force flush / close
+    {
+        let db = MBTiles::new(&mbtiles, workers).unwrap();
+        db.set_metadata(&metadata).unwrap();
+
+        let (snd, rcv) = channel::bounded(1);
+
+        crossbeam::scope(|s| {
+            // add tiles to queue
+            s.spawn(|_| {
+                let mut tiles: TileRange;
+                for zoom in minzoom..(maxzoom + 1) {
+                    tiles = TileRange::new(zoom, &mercator_bounds);
+                    let bar = ProgressBar::new(tiles.count() as u64)
+                        .with_style(ProgressStyle::default_bar().template(
+                            "{prefix:<8} {bar:50} {pos}/{len} {msg} [elapsed: {elapsed_precise}]]",
+                        ).unwrap())
+                        .with_prefix(format!("zoom: {}", zoom));
+
+                    for tile_id in tiles.iter() {
+                        snd.send(tile_id).unwrap();
+                        bar.inc(1);
+                    }
+
+                    bar.finish();
+                }
+
+                drop(snd);
+            });
+
+            let tiff = &tiff;
+            let db = &db;
+            let colormap = &colormap;
+            for _ in 0..workers {
+                let rcv = rcv.clone();
+
+                s.spawn(move |_| {
+                    match dtype {
+                        GdalDataType::UInt8 => {
+                            worker_u8(rcv, tiff, db, tilesize, colormap, disable_overviews)
+                                .unwrap();
+                        }
+                        GdalDataType::UInt32 => {
+                            worker_u32(rcv, tiff, db, tilesize, disable_overviews).unwrap();
+                        }
+                        // supported data types validated above
+                        _ => {
+                            unreachable!("data type not supported");
+                        }
+                    }
+                });
+            }
+        })
+        .unwrap();
+
+        db.update_index().unwrap();
+    }
+
+    // change the database back to non-WAL mode
+    MBTiles::flush(&mbtiles).unwrap();
+
+    Ok(())
+}
+
+fn worker_u8(
+    tiles: channel::Receiver<TileID>,
+    tiff_filename: &PathBuf,
+    db: &MBTiles,
+    tilesize: u16,
+    colormap_str: &Option<String>,
+    disable_overviews: bool,
+) -> Result<(), Box<dyn Error>> {
+    let dataset = Dataset::open(tiff_filename, disable_overviews)?;
+    let vrt = dataset.mercator_vrt()?;
+    let band = vrt.band(1)?;
+    let nodata = band.no_data_value().unwrap() as u8;
+
+    let conn = db.get_connection()?;
+
+    let width: u32 = tilesize as u32;
+    let height: u32 = width;
+
+    let (has_colormap, encoder): (bool, Box<dyn Encode<u8>>) = match colormap_str {
+        Some(c) => (
+            true,
+            Box::new(ColormapEncoder::<u8>::from_str(width, height, c, nodata).unwrap()),
+        ),
+        _ => (
+            false,
+            Box::new(GrayscaleEncoder::new(width, height, nodata)),
+        ),
+    };
+
+    // create buffers to receive data; these are automatically filled with
+    // the appropriate nodata value before reading from the raster
+    let mut buffer = vec![0u8; tilesize as usize * tilesize as usize];
+
+    let mut png_data: Vec<u8>;
+
+    for tile_id in tiles.iter() {
+        if vrt.read_tile(&band, tile_id, tilesize, &mut buffer, nodata)? {
+            if has_colormap {
+                png_data = encoder.encode(&buffer)?;
+            } else {
+                png_data = encoder.encode_8bit(&buffer)?;
+            }
+            db.write_tile(&conn, &tile_id, &png_data)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn worker_u32(
+    tiles: channel::Receiver<TileID>,
+    tiff_filename: &PathBuf,
+    db: &MBTiles,
+    tilesize: u16,
+    disable_overviews: bool,
+) -> Result<(), Box<dyn Error>> {
+    let dataset = Dataset::open(tiff_filename, disable_overviews)?;
+    let vrt = dataset.mercator_vrt()?;
+    let band = vrt.band(1)?;
+    let nodata = band.no_data_value().unwrap() as u32;
+
+    let conn = db.get_connection()?;
+
+    let width: u32 = tilesize as u32;
+    let height: u32 = width;
+
+    // get a function pointer for the RGBEncoder that defines specific type of data
+    let rgb_encoder = RGBEncoder::new(width, height, nodata);
+    let encode_rgb = <RGBEncoder as Encode<u32>>::encode_8bit;
+
+    let mut colormap_encoder: ColormapEncoder<u32> =
+        ColormapEncoder::new(width, height, nodata, 256)?;
+
+    let buffer_size = tilesize as usize * tilesize as usize;
+    let mut buffer = vec![nodata; buffer_size];
+    let mut rgb_buffer: Vec<u8> = vec![0u8; buffer_size * 3];
+    let mut color: Rgb8;
+    let mut png_data: Vec<u8>;
+    let mut use_palette: bool;
+
+    for tile_id in tiles.iter() {
+        if vrt.read_tile(&band, tile_id, tilesize, &mut buffer, nodata)? {
+            // // DEBUG: write raw data to TIFF for inspection
+            // let tile_bounds = tile_id.mercator_bounds();
+            // let xres = (tile_bounds.xmax - tile_bounds.xmin) as f64 / tilesize as f64;
+            // let yres = (tile_bounds.ymax - tile_bounds.ymin) as f64 / tilesize as f64;
+            // let transform = Affine::new(xres, 0., tile_bounds.xmin, 0., -yres, tile_bounds.ymax);
+
+            // write_raster(
+            //     format!("/tmp/test_{}_{}_{}.tif", tile_id.zoom, tile_id.x, tile_id.y),
+            //     tilesize as usize,
+            //     tilesize as usize,
+            //     &transform,
+            //     &SpatialRef::from_epsg(3857)?,
+            //     buffer.to_vec(),
+            //     nodata as f64,
+            // )
+            // .unwrap();
+
+            colormap_encoder.colormap.clear();
+            use_palette = true;
+
+            // convert value buffer to 8-bit RGB buffer, ignoring alpha
+            // also build up palette of unique values
+            for (i, &value) in buffer.iter().enumerate() {
+                color = Rgb8::from_u32(value);
+                rgb_buffer[i * 3] = color.r;
+                rgb_buffer[i * 3 + 1] = color.g;
+                rgb_buffer[i * 3 + 2] = color.b;
+
+                if colormap_encoder.colormap.len() < 256 {
+                    colormap_encoder.colormap.add_color(value, color);
+                } else {
+                    use_palette = false;
+                }
+            }
+
+            if use_palette {
+                png_data = colormap_encoder.encode(&buffer)?;
+            } else {
+                png_data = encode_rgb(&rgb_encoder, &rgb_buffer)?;
+            }
+
+            db.write_tile(&conn, &tile_id, &png_data)?;
+
+            // DEBUG: write rendered PNG to file
+            // fs::write(
+            //     format!("/tmp/test_{}_{}_{}.png", tile_id.zoom, tile_id.x, tile_id.y),
+            //     png_data,
+            // )
+            // .unwrap();
+        }
+    }
+
+    Ok(())
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use std::error::Error;
 // use std::fs;
 use std::path::PathBuf;
@@ -28,17 +30,7 @@ pub fn render_tiles(
     colormap: &Option<String>,
     disable_overviews: bool,
 ) -> Result<()> {
-    println!(
-        "Call: {:?} ({}) {:?}, name:{:?}, zooms: {}-{}",
-        tiff,
-        tiff.exists(),
-        mbtiles,
-        name,
-        minzoom,
-        maxzoom
-    );
-
-    let dataset = Dataset::open(&tiff, false).unwrap();
+    let dataset = Dataset::open(tiff, false).unwrap();
     let band = dataset.band(1).unwrap();
     let dtype = band.band_type();
     let geo_bounds = dataset.geo_bounds().unwrap();
@@ -101,7 +93,7 @@ pub fn render_tiles(
 
     // in a block so that connections are dropped to force flush / close
     {
-        let db = MBTiles::new(&mbtiles, workers).unwrap();
+        let db = MBTiles::new(mbtiles, workers).unwrap();
         db.set_metadata(&metadata).unwrap();
 
         let (snd, rcv) = channel::bounded(1);
@@ -158,7 +150,7 @@ pub fn render_tiles(
     }
 
     // change the database back to non-WAL mode
-    MBTiles::flush(&mbtiles).unwrap();
+    MBTiles::flush(mbtiles).unwrap();
 
     Ok(())
 }


### PR DESCRIPTION
This adds a `merge` subcommand to merge tilesets for different zoom levels back into a single tileset (e.g., if lower zooms are created using internal GeoTIFF overviews and higher zooms avoid those overviews).

This moves the render functionality to the `render` subcommand.

Other changes are just a matter of refactoring into files within the package.